### PR TITLE
Remove hardcoded API keys

### DIFF
--- a/spec/ohanakapa/client/categories_spec.rb
+++ b/spec/ohanakapa/client/categories_spec.rb
@@ -20,7 +20,7 @@ describe Ohanakapa::Client::Categories do
       cat_ids = ['52280f5c1edd37edff000001', '52280f5c1edd37edff000003']
       service = @client.replace_all_categories(service_id, cat_ids)
       expect(service.name).to match /CalFresh Application Assistance/
-      assert_requested :put, ohana_url("/services/#{service_id}/categories?api_token=5f996ce5c431a14c99419116a50a6b62&category_ids%5B0%5D=52280f5c1edd37edff000001&category_ids%5B1%5D=52280f5c1edd37edff000003")
+      assert_requested :put, ohana_url("/services/#{service_id}/categories?api_token=#{test_api_token}&category_ids%5B0%5D=52280f5c1edd37edff000001&category_ids%5B1%5D=52280f5c1edd37edff000003")
     end
   end # .replace_all_categories
 

--- a/spec/ohanakapa/client/keywords_spec.rb
+++ b/spec/ohanakapa/client/keywords_spec.rb
@@ -13,7 +13,7 @@ describe Ohanakapa::Client::Categories do
       keywords = ['apitest', 'sandbox']
       service = @client.add_keywords_to_a_service(service_id, keywords)
       expect(service.name).to match /CalFresh Application Assistance/
-      assert_requested :post, ohana_url("/services/#{service_id}/keywords?api_token=5f996ce5c431a14c99419116a50a6b62&keywords%5B0%5D=apitest&keywords%5B1%5D=sandbox")
+      assert_requested :post, ohana_url("/services/#{service_id}/keywords?api_token=#{test_api_token}&keywords%5B0%5D=apitest&keywords%5B1%5D=sandbox")
     end
   end # .add_keywords_to_a_service
 

--- a/spec/ohanakapa/client/locations_spec.rb
+++ b/spec/ohanakapa/client/locations_spec.rb
@@ -34,7 +34,7 @@ describe Ohanakapa::Client::Locations do
     it "updates a location's attributes" do
       location = @client.update_location("521d33a01974fcdb2b0036a9", :kind => "entertainment")
       expect(location.kind).to eq "Entertainment"
-      assert_requested :put, ohana_url("/locations/#{location.id}?api_token=5f996ce5c431a14c99419116a50a6b62&kind=entertainment")
+      assert_requested :put, ohana_url("/locations/#{location.id}?api_token=#{test_api_token}&kind=entertainment")
     end
   end # .update_location
 


### PR DESCRIPTION
After I run `export OHANAKAPA_TEST_API_TOKEN=12345 && bundle install && rake` on the CLI, three tests still fail because they have a hard coded API key. This PR should fix that.
